### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/amplify/#current-cloud-backend/auth/ddbstreamingui15aebfdf/ddbstreamingui15aebfdf-cloudformation-template.yml
+++ b/amplify/#current-cloud-backend/auth/ddbstreamingui15aebfdf/ddbstreamingui15aebfdf-cloudformation-template.yml
@@ -238,7 +238,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/auth/ddbstreamingui15aebfdf/ddbstreamingui15aebfdf-cloudformation-template.yml
+++ b/amplify/backend/auth/ddbstreamingui15aebfdf/ddbstreamingui15aebfdf-cloudformation-template.yml
@@ -238,7 +238,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/awscloudformation/nested-cloudformation-stack.yml
+++ b/amplify/backend/awscloudformation/nested-cloudformation-stack.yml
@@ -212,7 +212,7 @@
 					}
 				},
 				"Handler": "index.handler",
-				"Runtime": "nodejs10.x",
+				"Runtime": "nodejs14.x",
 				"Timeout": "300",
 				"Role": {
 					"Fn::GetAtt": [


### PR DESCRIPTION
CloudFormation templates in amazon-kinesis-data-streams-for-dynamodb have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.